### PR TITLE
Going to latest ruby2-alpine image as base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
-from ruby:2.2-onbuild
+FROM ruby:2-alpine
 
-WORKDIR /usr/src/app/src
+COPY Gemfile /app/
+COPY Gemfile.lock /app/
+RUN apk add --no-cache --virtual build-dependencies build-base && \
+    gem install bundler --no-ri --no-rdoc && \
+    cd /app; bundle install && \
+    apk del build-dependencies build-base
+COPY src/ /app/
+
+WORKDIR /app
 
 CMD bundle exec rake verify_pacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ COPY Gemfile.lock /app/
 RUN apk add --no-cache --virtual build-dependencies build-base && \
     gem install bundler --no-ri --no-rdoc && \
     cd /app; bundle install && \
-    apk del build-dependencies build-base
+    gem uninstall bundler && \
+    apk del build-dependencies build-base && \
+    rm -r ~/.bundle/ /usr/local/bundle/cache
 COPY src/ /app/
 
 WORKDIR /app


### PR DESCRIPTION
Minimizing image size for image pact-provider-verifier-docker

    > patched:  dius/pact-provider-verifier-docker  my-ms  ...   84.6MB
    > original: dius/pact-provider-verifier-docker  latest ...   747MB