### PR TITLE
dockerfile-changes: Remove bundler uninstall step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ COPY Gemfile.lock /app/
 RUN apk add --no-cache --virtual build-dependencies build-base && \
     gem install bundler && \
     cd /app; bundle install && \
-    gem uninstall bundler && \
     apk del build-dependencies build-base && \
     rm -r ~/.bundle/ /usr/local/bundle/cache
 COPY src/ /app/


### PR DESCRIPTION
When running pact-provider-verifier container, it needs bundler to run `bundle exec rake verify_pacts`

https://github.com/DiUS/pact-provider-verifier-docker/blob/master/Dockerfile#L15

![error-bundler-pact-verifier-docker](https://user-images.githubusercontent.com/245479/59926822-1e91d100-9409-11e9-9c44-316b976690cc.png)

This is a fix that removes the uninstall step that makes `bundle` command fails.
